### PR TITLE
修复config生成脚本的问题

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -43,4 +43,4 @@ read -p "请输入配置文件路径 > " configpath
 if [ -z $configpath ];then
 	configpath='/etc/minecraftspeedproxy/config.json'
 fi
-echo { \"Address\":\"$Address\", \"RemotePort\":\"$RemotePort\", \"LocalPort\":\"$LocalPort\", \"AllowInput\":\"$AllowInput\" } > $configpath
+echo { \"Address\":\"$Address\", \"RemotePort\":$RemotePort, \"LocalPort\":$LocalPort, \"AllowInput\":$AllowInput } > $configpath


### PR DESCRIPTION
一个显而易见的错误，萌新第一次写pr，有哪里不规范的还请指教（不会写sh脚本，要是会写我还想加一个判断路径是否存在，如果不存在就在当前目录创建，这对于我这种用centos直接用minecraftspeedproxy文件启动程序的很重要）